### PR TITLE
Fix get_holiday_name function

### DIFF
--- a/tests/handlers/loading_test.py
+++ b/tests/handlers/loading_test.py
@@ -39,9 +39,13 @@ def fx_tdcproject_key():
 async def test_get_holiday_name(fx_tdcproject_key):
     jan_first = datetime.datetime(2018, 1, 1)
     jan_second = datetime.datetime(2018, 1, 2)
+    armed_forces_day = datetime.datetime(2018, 10, 1)
 
     holiday = await get_holiday_name(fx_tdcproject_key, jan_first)
     assert holiday == '신정'
 
     holiday = await get_holiday_name(fx_tdcproject_key, jan_second)
+    assert holiday is None
+
+    holiday = await get_holiday_name(fx_tdcproject_key, armed_forces_day)
     assert holiday is None

--- a/yui/handlers/loading/monday.py
+++ b/yui/handlers/loading/monday.py
@@ -64,6 +64,7 @@ async def get_holiday_name(
     year, month, day = dt.strftime('%Y/%m/%d').split('/')
     url = 'https://apis.sktelecom.com/v1/eventday/days'
     params = {
+        'type': 'h',
         'year': year,
         'month': month,
         'day': day,


### PR DESCRIPTION
2018-10-01 is not holiday, but function return `'국군의 날'` because API
call had no type limit option. I add type option to fetch only national holiday.