### PR TITLE
 Support Slack Enterprise Grid

### DIFF
--- a/yui/apps/core.py
+++ b/yui/apps/core.py
@@ -114,6 +114,9 @@ async def on_team_join(bot, event: TeamJoin):
 
 @box.on(UserChange)
 async def on_user_change(bot, event: UserChange):
+    if not (event.user.id and event.user.team_id):
+        return False
+
     logger.info('on user change start')
     res = await retry(bot.api.users.info, event.user)
 

--- a/yui/types/base.py
+++ b/yui/types/base.py
@@ -1,4 +1,4 @@
-#: :type:`type` User ID type. It must start with 'U'.
+#: :type:`type` User ID type. It must start with 'U' or 'W'.
 UserID = str
 
 #: :type:`type` Public Channel ID type. It must start with 'C'.

--- a/yui/types/namespace.py
+++ b/yui/types/namespace.py
@@ -121,7 +121,7 @@ def user_id_convert(value):
         return id
 
     from .user import create_unknown_user  # circular dependency
-    if not id.startswith('U'):
+    if not (id.startswith('U') or id.startswith('W')):
         raise KeyError('Given ID value has unexpected prefix.')
     for obj in bot.users:
         if obj.id == id:
@@ -144,7 +144,7 @@ def id_convert(value):
     if id is None:
         return id
 
-    if id.startswith('U'):
+    if id.startswith('U') or id.startswith('W'):
         return user_id_convert(value)
     return channel_id_convert(value)
 


### PR DESCRIPTION
yui 를 Slack Enterprise Grid (with Active Directory 연동) 내부의 Workspace 로 데려와봤는데 몇 가지 문제점이 있어 수정했습니다.

* Enterprise Grid User 일부는 식별자가 'W' 로 시작합니다. 
   ref) https://api.slack.com/changelog/2016-08-11-user-id-format-changes
* Enterprise Grid에 사용자가 추가되면 team_id 가 비어있는 UserChanged 이벤트가 발생하는 바람에 DM부자가 됩니다...