### PR TITLE
Fix TypeError: object is not subscriptable

### DIFF
--- a/yui/apps/search/dns.py
+++ b/yui/apps/search/dns.py
@@ -165,5 +165,5 @@ async def dns(bot, event: Message, server_list: List[str], domain: str):
                     for r in result
                 )
             ),
-            thread_ts=chat['ts'],
+            thread_ts=chat.body['ts'],
         )


### PR DESCRIPTION
APIResponse 클래스가 refactoring 되면서 발생한 오류로 보입니다.

**Traceback**
```
Traceback (most recent call last):
  File "/home/yui/yui/yui/bot.py", line 276, in handle
    return await handler.run(self, event)
  File "/home/yui/yui/yui/box/apps/basic.py", line 92, in run
    return await self._run_message_event(bot, event)
  File "/home/yui/yui/yui/box/apps/basic.py", line 180, in _run_message_event
    res = await self.handler(**kwargs)
  File "/home/yui/yui/yui/apps/search/dns.py", line 168, in dns
    thread_ts=chat['ts'],
TypeError: 'APIResponse' object is not subscriptable
```