### PR TITLE
Fix leap year problem in age command

### DIFF
--- a/tests/apps/date/age_test.py
+++ b/tests/apps/date/age_test.py
@@ -15,6 +15,7 @@ async def test_age_command():
     event = bot.create_message('C1', 'U1')
     kirito_birthday = datetime.date(2008, 10, 7)
     leeseha_birthday = datetime.date(2003, 6, 3)
+    yunyun_birthday = datetime.date(2000, 2, 29)
 
     await age(bot, event, datetime.date(2000, 1, 1), kirito_birthday)
     said = bot.call_queue.pop()
@@ -23,6 +24,12 @@ async def test_age_command():
     assert said.data['text'] == '기준일 기준으로 아직 태어나지 않았어요!'
 
     await age(bot, event, datetime.date(2000, 1, 1), leeseha_birthday)
+    said = bot.call_queue.pop()
+    assert said.method == 'chat.postMessage'
+    assert said.data['channel'] == 'C1'
+    assert said.data['text'] == '기준일 기준으로 아직 태어나지 않았어요!'
+
+    await age(bot, event, datetime.date(2000, 1, 1), yunyun_birthday)
     said = bot.call_queue.pop()
     assert said.method == 'chat.postMessage'
     assert said.data['channel'] == 'C1'
@@ -52,6 +59,18 @@ async def test_age_command():
         '출생일로부터 0일 지났어요. 다음 생일까지 366일 남았어요.'
     )
 
+    await age(bot, event, datetime.date(2000, 2, 29), yunyun_birthday)
+    said = bot.call_queue.pop()
+    assert said.method == 'chat.postMessage'
+    assert said.data['channel'] == 'C1'
+    assert said.data['text'] == (
+        '2000년 02월 29일 출생자는 2000년 02월 29일 기준으로 다음과 같아요!\n\n'
+        '* 세는 나이(한국식 나이) 1세\n'
+        '* 연 나이(한국 일부 법령상 나이) 0세\n'
+        '* 만 나이(전세계 표준) 0세\n\n'
+        '출생일로부터 0일 지났어요. 다음 생일까지 365일 남았어요.'
+    )
+
     await age(bot, event, datetime.date(2009, 1, 1), kirito_birthday)
     said = bot.call_queue.pop()
     assert said.method == 'chat.postMessage'
@@ -74,4 +93,16 @@ async def test_age_command():
         '* 연 나이(한국 일부 법령상 나이) 1세\n'
         '* 만 나이(전세계 표준) 0세\n\n'
         '출생일로부터 212일 지났어요. 다음 생일까지 154일 남았어요.'
+    )
+
+    await age(bot, event, datetime.date(2001, 1, 1), yunyun_birthday)
+    said = bot.call_queue.pop()
+    assert said.method == 'chat.postMessage'
+    assert said.data['channel'] == 'C1'
+    assert said.data['text'] == (
+        '2000년 02월 29일 출생자는 2001년 01월 01일 기준으로 다음과 같아요!\n\n'
+        '* 세는 나이(한국식 나이) 2세\n'
+        '* 연 나이(한국 일부 법령상 나이) 1세\n'
+        '* 만 나이(전세계 표준) 0세\n\n'
+        '출생일로부터 307일 지났어요. 다음 생일까지 58일 남았어요.'
     )

--- a/yui/apps/date/age.py
+++ b/yui/apps/date/age.py
@@ -1,5 +1,7 @@
 import datetime
 
+from dateutil.relativedelta import relativedelta
+
 from ...box import box
 from ...command import argument, option
 from ...event import Message
@@ -38,19 +40,14 @@ async def age(
         )
         return
 
-    year_age = today.year - birthday.year
+    global_age = relativedelta(today, birthday).years
+    year_age = relativedelta(today, datetime.date(birthday.year, 1, 1)).years
     korean_age = year_age + 1
 
-    global_age = today.year - birthday.year
-    cond1 = today.month < birthday.month
-    cond2 = today.month == birthday.month and today.day < birthday.day
-    if cond1 or cond2:
-        global_age -= 1
-
-    this_year_birthday = birthday.replace(today.year)
+    this_year_birthday = birthday + relativedelta(years=year_age)
     remain = this_year_birthday.toordinal() - today.toordinal()
     if remain < 1:
-        next_year_birthday = birthday.replace(today.year + 1)
+        next_year_birthday = birthday + relativedelta(years=year_age + 1)
         remain = next_year_birthday.toordinal() - today.toordinal()
 
     await bot.say(


### PR DESCRIPTION
생일이 윤년의 2월 29일인 경우 올해 생일을 계산하면서 ValueError 예외가 발생합니다.

**Traceback**
```Traceback (most recent call last):
  File "/home/yui/yui/yui/bot.py", line 276, in handle
    return await handler.run(self, event)
  File "/home/yui/yui/yui/box/apps/basic.py", line 92, in run
    return await self._run_message_event(bot, event)
  File "/home/yui/yui/yui/box/apps/basic.py", line 180, in _run_message_event
    res = await self.handler(**kwargs)
  File "/home/yui/yui/yui/apps/date/age.py", line 50, in age
    this_year_birthday = birthday.replace(today.year)
ValueError: day is out of range for month
```