### PR TITLE
Fix receive timeout if user id or team id is empty

### DIFF
--- a/yui/apps/core.py
+++ b/yui/apps/core.py
@@ -115,7 +115,7 @@ async def on_team_join(bot, event: TeamJoin):
 @box.on(UserChange)
 async def on_user_change(bot, event: UserChange):
     if not (event.user.id and event.user.team_id):
-        return False
+        return True
 
     logger.info('on user change start')
     res = await retry(bot.api.users.info, event.user)


### PR DESCRIPTION
```
18:06:43 INFO yui.bot.Bot.process UserChange(user=User(id='WXXXXXXXX', name='XXXXXXXXXXX', team_id='', is_unknown=True))

...

18:11:43 ERROR yui.bot.Bot.receive receive timeout(300)
18:11:43 INFO yui.bot.Bot.receive BotReconnect raised. I will reconnect to rtm.
```

Slack Enterprise Grid 의 경우, UserChange 이벤트가 현재 Workspace 참여자 뿐만 아니라 Grid 내 다른 Workspace 참여자에 대해서도 발생합니다.
이때 team_id 값이 비어서 전달됩니다만, 이런 경우 return 하는 값이 False 였어서 처리되지 않은 Event 로 분류되어서 그런지 Bot.receive 가 Timeout 을 일으키고 있습니다 ㅜㅜ